### PR TITLE
Add not found e2e test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format:check": "prettier --check 'src/**/*.{js,css,md,yml}'",
     "lint": "eslint . --ext .js",
     "test:e2e": "start-server-and-test 'next dev --port 3001' 3001 'cypress run --headless'",
-    "test:e2e:interactive": "cypress open"
+    "test:e2e:interactive": "start-server-and-test 'next dev --port 3001' 3001 'cypress open'"
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/test/e2e/user-visits-not-found-page.test.js
+++ b/test/e2e/user-visits-not-found-page.test.js
@@ -1,0 +1,15 @@
+describe("User visits not found page", function () {
+  it("displays the 404 page", function () {
+    whenIVisitAPageThatDoesNotExist();
+
+    thenISeeTheNotFoundPage();
+  });
+
+  function whenIVisitAPageThatDoesNotExist() {
+    cy.visit("/foo", { failOnStatusCode: false });
+  }
+
+  function thenISeeTheNotFoundPage() {
+    cy.title().should("contains", "Page not found");
+  }
+});


### PR DESCRIPTION
## Context

I neglected to add an end to end test for the 404 page.

## Changes proposed in this pull request

This PR adds an e2e test to ensure that if a user goes to a page that doesn't exist, then they get redirected to the 404 page. It also updates the `test:e2e:interactive` command to use `start-server-and-test`.

## Guidance to review

N/A

## Link to Notion card

N/A